### PR TITLE
ARCH-2023

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@alec-malcolm @michael-peto-camis

--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ outputs:
   username:
     description: The matching Slack user's username
 runs:
-  using: node18
+  using: node16
   main: dist/index.js
 branding:
   icon: 'at-sign'


### PR DESCRIPTION
# What was the issue?
- node18 is unsupported in github actions runners and there seems to be no movement on that update

# What's changed?
- reverted change to use node18 in favour of more compatible node16. Also added code owners to repo (@alec-malcolm @michael-peto-camis)