### PR TITLE
PIPELINE-229 - changes user fetch to grab author email from commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A lightweight GitHub Action that can be used to fetch a user's slack member id for usage in automated slack notifications by their associated GitHub username. This action works by taking the username in GitHub retrieving the user's email associated with the GitHub account, and then finding a slack user that's associated with that email. If one is found the slack member id for that user is set as the output variable.
 
 ## Inputs
-* username - This should match the github.actor property of the job that is using this action.
+* username - This should match the github.actor property of the job that is using this action (No longer necessary, achieved through GitHub context)
 * github-token - This is the authentication token used in the github context that will give this action access to the github user
 * slack-token - This is the API Key for a Slack Instance. It will allow us to fetch a list of slack users and from there determine their slack id.
 

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ author: 'Camis Inc'
 inputs:
   username:
     description: The username of the user in GitHub to fetch in Slack
-    required: true
+    required: optional
   github-token:
     description: The github token used to retrieve information about the provided GitHub user 
     required: true

--- a/dist/index.js
+++ b/dist/index.js
@@ -18833,37 +18833,94 @@ module.exports = JSON.parse('[[[0,44],"disallowed_STD3_valid"],[[45,46],"valid"]
 /******/ 	}
 /******/ 	
 /************************************************************************/
+/******/ 	/* webpack/runtime/compat get default export */
+/******/ 	(() => {
+/******/ 		// getDefaultExport function for compatibility with non-harmony modules
+/******/ 		__nccwpck_require__.n = (module) => {
+/******/ 			var getter = module && module.__esModule ?
+/******/ 				() => (module['default']) :
+/******/ 				() => (module);
+/******/ 			__nccwpck_require__.d(getter, { a: getter });
+/******/ 			return getter;
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__nccwpck_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__nccwpck_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
 /******/ 	/* webpack/runtime/compat */
 /******/ 	
 /******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";
 /******/ 	
 /************************************************************************/
 var __webpack_exports__ = {};
-// This entry need to be wrapped in an IIFE because it need to be isolated against other modules in the chunk.
+// This entry need to be wrapped in an IIFE because it need to be in strict mode.
 (() => {
-const { WebClient } = __nccwpck_require__(431);
-const core = __nccwpck_require__(2186);
-const github = __nccwpck_require__(5438);
+"use strict";
+__nccwpck_require__.r(__webpack_exports__);
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0__ = __nccwpck_require__(2186);
+/* harmony import */ var _actions_core__WEBPACK_IMPORTED_MODULE_0___default = /*#__PURE__*/__nccwpck_require__.n(_actions_core__WEBPACK_IMPORTED_MODULE_0__);
+/* harmony import */ var _slack_web_api__WEBPACK_IMPORTED_MODULE_1__ = __nccwpck_require__(431);
+/* harmony import */ var _slack_web_api__WEBPACK_IMPORTED_MODULE_1___default = /*#__PURE__*/__nccwpck_require__.n(_slack_web_api__WEBPACK_IMPORTED_MODULE_1__);
+/* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_2__ = __nccwpck_require__(5438);
+/* harmony import */ var _actions_github__WEBPACK_IMPORTED_MODULE_2___default = /*#__PURE__*/__nccwpck_require__.n(_actions_github__WEBPACK_IMPORTED_MODULE_2__);
+
+
+
 
 /**
  * Given a user's username in GitHub the user's email is retrieved
- * @param {*} username A username associated with a user in GitHub.
  * @param {*} token GitHub Personal Access Token, used to interact with the GitHub REST API
  * @returns The GitHub user's email address
  */
-async function fetchGitHubEmail(username, token) {
+async function fetchGitHubEmail(token) {
     try {
-        const octokit = github.getOctokit(token);
-        // Fetch the user information by the provided GitHub username.
-        const result = await octokit.rest.users.getByUsername({
-            username
+        const octokit = (0,_actions_github__WEBPACK_IMPORTED_MODULE_2__.getOctokit)(token);
+        // Fetch commit from GitHub
+        const data = await octokit.rest.repos.getCommit({
+            owner: _actions_github__WEBPACK_IMPORTED_MODULE_2__.context.repo.owner,
+            repo: _actions_github__WEBPACK_IMPORTED_MODULE_2__.context.repo.repo,
+            ref: _actions_github__WEBPACK_IMPORTED_MODULE_2__.context.sha
         });
-        if (!result || !result.data || !result.data.email) {
+
+        if (!data) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed('An error occurred fetching the commit from GitHub');
             return undefined;
         }
-        // Set the email to the one just retrieved from GitHub.
-        return result.data.email;
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.debug(`commit: ${JSON.stringify(data)}`);
+        // Retrieve the email address associated with the commit
+        const email = data.data.commit.author.email;
+        if (!email) {
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed("Could not find an email address associated with the commit");
+        }
+        return email;
     } catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`error: ${err}`);
         return undefined;
     }
 }
@@ -18877,23 +18934,24 @@ async function fetchGitHubEmail(username, token) {
 async function fetchSlackUser(email, token) {
     try {
         // Initialize an instance of the slack web client.
-        const web = new WebClient(token);
+        const web = new _slack_web_api__WEBPACK_IMPORTED_MODULE_1__.WebClient(token);
 
         // Fetch all slack users
         const result = await web.users.list();
         if (!result.ok) {
-            core.setFailed('An error occurred fetching users from slack');
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed('An error occurred fetching users from slack');
             return undefined;
         }
 
         // Find the slack user associated with the github email address
-        const user = result.members.find( member => member.profile.email === email);
+        const user = result.members.find(member => member.profile.email === email);
         if (!user) {
-            core.setFailed('Could not find an associated slack user');
+            _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`Could not find an associated slack user ${email}`);
             return undefined;
         }
         return { memberId: user.id, username: user.name};
     } catch (err) {
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`error: ${err}`)
         return undefined;
     }
 }
@@ -18902,25 +18960,24 @@ async function fetchSlackUser(email, token) {
  * Main orchestration function, takes in input from github actions and sets the output to the slack member id if one was found.
  */
 (async () => {
-    const username = core.getInput('username');
-    const githubToken = core.getInput('github-token');
-    const slackToken = core.getInput('slack-token');
+    const githubToken = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('github-token');
+    const slackToken = _actions_core__WEBPACK_IMPORTED_MODULE_0__.getInput('slack-token');
 
     // Retrieve the user's email in GitHub
-    const email = await fetchGitHubEmail(username, githubToken);
+    const email = await fetchGitHubEmail(githubToken);
     if (!email) {
-        core.setFailed(`Failed to set email for github user ${username}`);
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`Failed to find email associated with commit`);
         return;
     }
     
     // Retrieve the user's member id in slack
     const slackUser = await fetchSlackUser(email, slackToken);
     if (!slackUser) {
-        core.setFailed(`An error occurred fetching user from slack with email ${email}`);
+        _actions_core__WEBPACK_IMPORTED_MODULE_0__.setFailed(`An error occurred fetching user from slack with email ${email}`);
         return;
     }
-    core.setOutput('member-id', slackUser.memberId);
-    core.setOutput('username', slackUser.username);
+    _actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput('member-id', slackUser.memberId);
+    _actions_core__WEBPACK_IMPORTED_MODULE_0__.setOutput('username', slackUser.username);
 })();
 })();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -148,34 +148,31 @@
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.7.tgz",
-      "integrity": "sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==",
+      "version": "19.0.13",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
+      "integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
       "dependencies": {
-        "@octokit/core": "^4.1.0",
-        "@octokit/plugin-paginate-rest": "^6.0.0",
+        "@octokit/core": "^4.2.1",
+        "@octokit/plugin-paginate-rest": "^6.1.2",
         "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^7.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
       },
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/@octokit/rest/node_modules/@octokit/auth-token": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
-      "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
-      "dependencies": {
-        "@octokit/types": "^9.0.0"
-      },
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+      "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ==",
       "engines": {
         "node": ">= 14"
       }
     },
     "node_modules/@octokit/rest/node_modules/@octokit/core": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.0.tgz",
-      "integrity": "sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+      "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
       "dependencies": {
         "@octokit/auth-token": "^3.0.0",
         "@octokit/graphql": "^5.0.0",
@@ -190,9 +187,9 @@
       }
     },
     "node_modules/@octokit/rest/node_modules/@octokit/endpoint": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
-      "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+      "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
       "dependencies": {
         "@octokit/types": "^9.0.0",
         "is-plain-object": "^5.0.0",
@@ -203,9 +200,9 @@
       }
     },
     "node_modules/@octokit/rest/node_modules/@octokit/graphql": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.5.tgz",
-      "integrity": "sha512-Qwfvh3xdqKtIznjX9lz2D458r7dJPP8l6r4GQkIdWQouZwHQK0mVT88uwiU2bdTU2OtT1uOlKpRciUWldpG0yQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+      "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
       "dependencies": {
         "@octokit/request": "^6.0.0",
         "@octokit/types": "^9.0.0",
@@ -216,16 +213,17 @@
       }
     },
     "node_modules/@octokit/rest/node_modules/@octokit/openapi-types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
-      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+      "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
     },
     "node_modules/@octokit/rest/node_modules/@octokit/plugin-paginate-rest": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.0.0.tgz",
-      "integrity": "sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+      "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
       "dependencies": {
-        "@octokit/types": "^9.0.0"
+        "@octokit/tsconfig": "^1.0.2",
+        "@octokit/types": "^9.2.3"
       },
       "engines": {
         "node": ">= 14"
@@ -235,12 +233,11 @@
       }
     },
     "node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.0.1.tgz",
-      "integrity": "sha512-pnCaLwZBudK5xCdrR823xHGNgqOzRnJ/mpC/76YPpNP7DybdsJtP7mdOwh+wYZxK5jqeQuhu59ogMI4NRlBUvA==",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
+      "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
       "dependencies": {
-        "@octokit/types": "^9.0.0",
-        "deprecation": "^2.3.1"
+        "@octokit/types": "^10.0.0"
       },
       "engines": {
         "node": ">= 14"
@@ -249,10 +246,18 @@
         "@octokit/core": ">=3"
       }
     },
+    "node_modules/@octokit/rest/node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+      "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+      "dependencies": {
+        "@octokit/openapi-types": "^18.0.0"
+      }
+    },
     "node_modules/@octokit/rest/node_modules/@octokit/request": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.3.tgz",
-      "integrity": "sha512-TNAodj5yNzrrZ/VxP+H5HiYaZep0H3GU0O7PaF+fhDrt8FPrnkei9Aal/txsN/1P7V3CPiThG0tIvpPDYUsyAA==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+      "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
       "dependencies": {
         "@octokit/endpoint": "^7.0.0",
         "@octokit/request-error": "^3.0.0",
@@ -279,12 +284,17 @@
       }
     },
     "node_modules/@octokit/rest/node_modules/@octokit/types": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
-      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+      "version": "9.3.2",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+      "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
       "dependencies": {
-        "@octokit/openapi-types": "^16.0.0"
+        "@octokit/openapi-types": "^18.0.0"
       }
+    },
+    "node_modules/@octokit/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
     },
     "node_modules/@octokit/types": {
       "version": "6.41.0",
@@ -752,28 +762,25 @@
       }
     },
     "@octokit/rest": {
-      "version": "19.0.7",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.7.tgz",
-      "integrity": "sha512-HRtSfjrWmWVNp2uAkEpQnuGMJsu/+dBr47dRc5QVgsCbnIc1+GFEaoKBWkYG+zjrsHpSqcAElMio+n10c0b5JA==",
+      "version": "19.0.13",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.13.tgz",
+      "integrity": "sha512-/EzVox5V9gYGdbAI+ovYj3nXQT1TtTHRT+0eZPcuC05UFSWO3mdO9UY1C0i2eLF9Un1ONJkAk+IEtYGAC+TahA==",
       "requires": {
-        "@octokit/core": "^4.1.0",
-        "@octokit/plugin-paginate-rest": "^6.0.0",
+        "@octokit/core": "^4.2.1",
+        "@octokit/plugin-paginate-rest": "^6.1.2",
         "@octokit/plugin-request-log": "^1.0.4",
-        "@octokit/plugin-rest-endpoint-methods": "^7.0.0"
+        "@octokit/plugin-rest-endpoint-methods": "^7.1.2"
       },
       "dependencies": {
         "@octokit/auth-token": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.3.tgz",
-          "integrity": "sha512-/aFM2M4HVDBT/jjDBa84sJniv1t9Gm/rLkalaz9htOm+L+8JMj1k9w0CkUdcxNyNxZPlTxKPVko+m1VlM58ZVA==",
-          "requires": {
-            "@octokit/types": "^9.0.0"
-          }
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.4.tgz",
+          "integrity": "sha512-TWFX7cZF2LXoCvdmJWY7XVPi74aSY0+FfBZNSXEXFkMpjcqsQwDSYVv5FhRFaI0V1ECnwbz4j59T/G+rXNWaIQ=="
         },
         "@octokit/core": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.0.tgz",
-          "integrity": "sha512-AgvDRUg3COpR82P7PBdGZF/NNqGmtMq2NiPqeSsDIeCfYFOZ9gddqWNQHnFdEUf+YwOj4aZYmJnlPp7OXmDIDg==",
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.2.4.tgz",
+          "integrity": "sha512-rYKilwgzQ7/imScn3M9/pFfUf4I1AZEH3KhyJmtPdE2zfaXAn2mFfUy4FbKewzc2We5y/LlKLj36fWJLKC2SIQ==",
           "requires": {
             "@octokit/auth-token": "^3.0.0",
             "@octokit/graphql": "^5.0.0",
@@ -785,9 +792,9 @@
           }
         },
         "@octokit/endpoint": {
-          "version": "7.0.5",
-          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.5.tgz",
-          "integrity": "sha512-LG4o4HMY1Xoaec87IqQ41TQ+glvIeTKqfjkCEmt5AIwDZJwQeVZFIEYXrYY6yLwK+pAScb9Gj4q+Nz2qSw1roA==",
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.6.tgz",
+          "integrity": "sha512-5L4fseVRUsDFGR00tMWD/Trdeeihn999rTMGRMC1G/Ldi1uWlWJzI98H4Iak5DB/RVvQuyMYKqSK/R6mbSOQyg==",
           "requires": {
             "@octokit/types": "^9.0.0",
             "is-plain-object": "^5.0.0",
@@ -795,9 +802,9 @@
           }
         },
         "@octokit/graphql": {
-          "version": "5.0.5",
-          "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.5.tgz",
-          "integrity": "sha512-Qwfvh3xdqKtIznjX9lz2D458r7dJPP8l6r4GQkIdWQouZwHQK0mVT88uwiU2bdTU2OtT1uOlKpRciUWldpG0yQ==",
+          "version": "5.0.6",
+          "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.6.tgz",
+          "integrity": "sha512-Fxyxdy/JH0MnIB5h+UQ3yCoh1FG4kWXfFKkpWqjZHw/p+Kc8Y44Hu/kCgNBT6nU1shNumEchmW/sUO1JuQnPcw==",
           "requires": {
             "@octokit/request": "^6.0.0",
             "@octokit/types": "^9.0.0",
@@ -805,31 +812,41 @@
           }
         },
         "@octokit/openapi-types": {
-          "version": "16.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
-          "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA=="
+          "version": "18.0.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-18.0.0.tgz",
+          "integrity": "sha512-V8GImKs3TeQRxRtXFpG2wl19V7444NIOTDF24AWuIbmNaNYOQMWRbjcGDXV5B+0n887fgDcuMNOmlul+k+oJtw=="
         },
         "@octokit/plugin-paginate-rest": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.0.0.tgz",
-          "integrity": "sha512-Sq5VU1PfT6/JyuXPyt04KZNVsFOSBaYOAq2QRZUwzVlI10KFvcbUo8lR258AAQL1Et60b0WuVik+zOWKLuDZxw==",
+          "version": "6.1.2",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-6.1.2.tgz",
+          "integrity": "sha512-qhrmtQeHU/IivxucOV1bbI/xZyC/iOBhclokv7Sut5vnejAIAEXVcGQeRpQlU39E0WwK9lNvJHphHri/DB6lbQ==",
           "requires": {
-            "@octokit/types": "^9.0.0"
+            "@octokit/tsconfig": "^1.0.2",
+            "@octokit/types": "^9.2.3"
           }
         },
         "@octokit/plugin-rest-endpoint-methods": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.0.1.tgz",
-          "integrity": "sha512-pnCaLwZBudK5xCdrR823xHGNgqOzRnJ/mpC/76YPpNP7DybdsJtP7mdOwh+wYZxK5jqeQuhu59ogMI4NRlBUvA==",
+          "version": "7.2.3",
+          "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-7.2.3.tgz",
+          "integrity": "sha512-I5Gml6kTAkzVlN7KCtjOM+Ruwe/rQppp0QU372K1GP7kNOYEKe8Xn5BW4sE62JAHdwpq95OQK/qGNyKQMUzVgA==",
           "requires": {
-            "@octokit/types": "^9.0.0",
-            "deprecation": "^2.3.1"
+            "@octokit/types": "^10.0.0"
+          },
+          "dependencies": {
+            "@octokit/types": {
+              "version": "10.0.0",
+              "resolved": "https://registry.npmjs.org/@octokit/types/-/types-10.0.0.tgz",
+              "integrity": "sha512-Vm8IddVmhCgU1fxC1eyinpwqzXPEYu0NrYzD3YZjlGjyftdLBTeqNblRC0jmJmgxbJIsQlyogVeGnrNaaMVzIg==",
+              "requires": {
+                "@octokit/openapi-types": "^18.0.0"
+              }
+            }
           }
         },
         "@octokit/request": {
-          "version": "6.2.3",
-          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.3.tgz",
-          "integrity": "sha512-TNAodj5yNzrrZ/VxP+H5HiYaZep0H3GU0O7PaF+fhDrt8FPrnkei9Aal/txsN/1P7V3CPiThG0tIvpPDYUsyAA==",
+          "version": "6.2.8",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.8.tgz",
+          "integrity": "sha512-ow4+pkVQ+6XVVsekSYBzJC0VTVvh/FCTUUgTsboGq+DTeWdyIFV8WSCdo0RIxk6wSkBTHqIK1mYuY7nOBXOchw==",
           "requires": {
             "@octokit/endpoint": "^7.0.0",
             "@octokit/request-error": "^3.0.0",
@@ -850,14 +867,19 @@
           }
         },
         "@octokit/types": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
-          "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+          "version": "9.3.2",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.3.2.tgz",
+          "integrity": "sha512-D4iHGTdAnEEVsB8fl95m1hiz7D5YiRdQ9b/OEb3BYRVwbLsGHcRVPz+u+BgRLNk0Q0/4iZCBqDN96j2XNxfXrA==",
           "requires": {
-            "@octokit/openapi-types": "^16.0.0"
+            "@octokit/openapi-types": "^18.0.0"
           }
         }
       }
+    },
+    "@octokit/tsconfig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@octokit/tsconfig/-/tsconfig-1.0.2.tgz",
+      "integrity": "sha512-I0vDR0rdtP8p2lGMzvsJzbhdOWy405HcGovrspJ8RRibHnyRgggUSNO5AIox5LmqiwmatHKYsvj6VGFHkqS7lA=="
     },
     "@octokit/types": {
       "version": "6.41.0",


### PR DESCRIPTION
# What was the issue?
- If the GitHub user did not have a publicly visible email the action would fail to set the email used for slack user retrieval

# What's changed?
- The git commit author's email is used since that does not seem to have the same visibility permissions configured