### PR TITLE
DEVOPS-7961 - Update action to run on Node 20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ outputs:
   username:
     description: The matching Slack user's username
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 branding:
   icon: 'at-sign'


### PR DESCRIPTION
Actions have been forced to run on Node 20 for a while now according to https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/. Update action definition to match so it stops throwing warnings in other workflows.