### PR TITLE
DEVOPS-9353 - Get PR head SHA instead of target branch head SHA

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -74655,11 +74655,15 @@ async function fetchGitHubEmailByContextSha(token) {
     try {
         const octokit = getOctokit(token);
 
+        // For pull requests, use the PR head SHA instead of context.sha
+        // context.sha points to the merge commit or base branch in PR contexts
+        const sha = github_context.payload.pull_request?.head?.sha || github_context.sha;
+
         // Fetch commit from GitHub
         const data = await octokit.rest.repos.getCommit({
             owner: github_context.repo.owner,
             repo: github_context.repo.repo,
-            ref: github_context.sha
+            ref: sha
         });
 
         if (!data) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -972,7 +972,8 @@
         "@octokit/plugin-request-log": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-          "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q=="
+          "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+          "requires": {}
         },
         "@octokit/plugin-rest-endpoint-methods": {
           "version": "16.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,15 @@ async function fetchGitHubEmailByContextSha(token) {
     try {
         const octokit = getOctokit(token);
 
+        // For pull requests, use the PR head SHA instead of context.sha
+        // context.sha points to the merge commit or base branch in PR contexts
+        const sha = context.payload.pull_request?.head?.sha || context.sha;
+
         // Fetch commit from GitHub
         const data = await octokit.rest.repos.getCommit({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            ref: context.sha
+            ref: sha
         });
 
         if (!data) {


### PR DESCRIPTION
Original method would cause notifications to go to the latest committer on the target branch rather than the author of the PR commits.