### PR TITLE
CAM-26766 - Update node runner to 24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -17,7 +17,7 @@ outputs:
   username:
     description: The matching Slack user's username
 runs:
-  using: node20
+  using: node24
   main: dist/index.js
 branding:
   icon: 'at-sign'


### PR DESCRIPTION
To resolve: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Note that this doesn't cover any action items flagged by `npm audit` or the Dependabot updates. That will be it's own set of work or covered by a rewrite as needed.